### PR TITLE
Fixed AllRoles annotation

### DIFF
--- a/src/main/java/core/english/mse2023/aop/annotation/handler/AllRoles.java
+++ b/src/main/java/core/english/mse2023/aop/annotation/handler/AllRoles.java
@@ -3,7 +3,10 @@ package core.english.mse2023.aop.annotation.handler;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-@AllRegisteredRoles
+@AdminRole
+@ParentRole
+@StudentRole
+@TeacherRole
 @GuestRole
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AllRoles {

--- a/src/main/java/core/english/mse2023/handler/impl/info/GetAllSubscriptionsHandler.java
+++ b/src/main/java/core/english/mse2023/handler/impl/info/GetAllSubscriptionsHandler.java
@@ -26,10 +26,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GetAllSubscriptionsHandler implements Handler {
 
-    private static final String NO_FAMILY_SUBSCRIPTIONS_TEXT = "В вашей семье нет подписок.";
-    private static final String NO_TEACHER_SUBSCRIPTIONS_TEXT = "Нет подписок, в которых вы являетесь преподавателем.";
-    private static final String NO_STUDENT_SUBSCRIPTIONS_TEXT = "Нет подписок, в которых вы являетесь студентом.";
-    private static final String NO_SUBSCRIPTIONS_TEXT = "В системе нет подписок";
+    private static final String NO_FAMILY_SUBSCRIPTIONS_TEXT = "В вашей семье нет не отмененных подписок.";
+    private static final String NO_TEACHER_SUBSCRIPTIONS_TEXT = "Нет не отмененных подписок, в которых вы являетесь преподавателем.";
+    private static final String NO_STUDENT_SUBSCRIPTIONS_TEXT = "Нет не отмененных подписок, в которых вы являетесь студентом.";
+    private static final String NO_SUBSCRIPTIONS_TEXT = "В системе нет не отмененных подписок.";
 
     private static final String DATA_PATTERN = """
             Тип: %s
@@ -77,7 +77,7 @@ public class GetAllSubscriptionsHandler implements Handler {
 
     private List<BotApiMethod<?>> createMessagesWithButton(List<Subscription> subscriptions, String chatId, UserRole userRole) {
 
-        if (subscriptions.size() == 0) {
+        if (subscriptions.size() == 0 || subscriptions.stream().allMatch((subscription -> subscription.getStatus() == SubscriptionStatus.CANCELLED))) {
             if (userRole == UserRole.PARENT) {
                 return List.of(SendMessage.builder()
                         .chatId(chatId)

--- a/src/main/java/core/english/mse2023/handler/impl/info/GetAllTeachersHandler.java
+++ b/src/main/java/core/english/mse2023/handler/impl/info/GetAllTeachersHandler.java
@@ -29,7 +29,7 @@ public class GetAllTeachersHandler implements Handler {
 
     private static final String START_TEXT = "Список зарегистрированных преподавателей:";
     private static final String NO_TEACHERS_TEXT = "Зарегистрированные преподаватели отсутствуют в системе.";
-    private static final String USER_DATA_PATTERN = " - %s%s";
+    private static final String USER_DATA_PATTERN = "%s%s";
 
     private final UserService service;
 


### PR DESCRIPTION
Также починил:
- В GetAllSubscriptionsHandler проверка идет не только на отсутствие подписок, но и на отсуствие в таком списке неотмененных подписок. Без этого казалось, что команда не отрабатывала функционал.
- В GetAllTeachersHandler паттерн у имен учителей почему-то имел тире. Убрал его