### PR TITLE
Добавить возможность создавать круговые диаграммы для статистики в PDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <statemachine.version>3.2.0</statemachine.version>
         <thymeleaf.version>3.1.1.RELEASE</thymeleaf.version>
         <flying-saucer-pdf.version>9.1.22</flying-saucer-pdf.version>
+        <xchart.version>3.8.3</xchart.version>
     </properties>
     <dependencies>
         <dependency>
@@ -87,6 +88,11 @@
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>
             <version>${flying-saucer-pdf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.knowm.xchart</groupId>
+            <artifactId>xchart</artifactId>
+            <version>${xchart.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/core/english/mse2023/service/impl/PDFServiceImpl.java
+++ b/src/main/java/core/english/mse2023/service/impl/PDFServiceImpl.java
@@ -2,15 +2,20 @@ package core.english.mse2023.service.impl;
 
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.pdf.BaseFont;
-import core.english.mse2023.dto.GetStudentStatisticDTO;
 import core.english.mse2023.dto.ThymeleafLessonDTO;
 import core.english.mse2023.model.Lesson;
+import core.english.mse2023.model.LessonInfo;
 import core.english.mse2023.model.Subscription;
 import core.english.mse2023.model.User;
 import core.english.mse2023.service.LessonService;
 import core.english.mse2023.service.PDFService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.PieChart;
+import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.style.PieStyler;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternUtils;
@@ -21,12 +26,13 @@ import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 
+import java.awt.*;
 import java.io.*;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.List;
-import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -54,7 +60,7 @@ public class PDFServiceImpl implements PDFService {
         return generatePdfFromHtml(parsedTemplate);
     }
 
-    private String parseStudentStatisticsThymeleafTemplate(List<Lesson> lessons, User student, Timestamp startDate, Timestamp endDate) {
+    private String parseStudentStatisticsThymeleafTemplate(List<Lesson> lessons, User student, Timestamp startDate, Timestamp endDate) throws IOException {
         ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
         templateResolver.setSuffix(".html");
         templateResolver.setTemplateMode(TemplateMode.HTML);
@@ -64,6 +70,8 @@ public class PDFServiceImpl implements PDFService {
 
         List<ThymeleafLessonDTO> lessonDTOS = new ArrayList<>();
 
+        Map<String, Integer> markData = new HashMap<>();
+
         for (Lesson lesson : lessons) {
             ThymeleafLessonDTO lessonDTO = ThymeleafLessonDTO.builder()
                     .topic(lesson.getTopic())
@@ -71,8 +79,20 @@ public class PDFServiceImpl implements PDFService {
                     .status(lesson.getStatus().toString())
                     .build();
             lessonDTOS.add(lessonDTO);
+
+            LessonInfo lessonInfo = lessonService.getLessonInfoByLessonId(lesson.getId());
+
+            if (lessonInfo.getScore() != null) {
+                String key = "Оценка \"" + (lessonInfo.getScore() - 2) + "\"";
+                if (!markData.containsKey(key)) {
+                    markData.put(key, 1);
+                } else {
+                    markData.put(key, markData.get(key) + 1);
+                }
+            }
         }
 
+        String marksPieChartString = createPieChartImageBase64(markData);
 
         Context context = new Context();
         context.setVariable(
@@ -84,6 +104,8 @@ public class PDFServiceImpl implements PDFService {
         context.setVariable("startDate", dateFormat.format(startDate));
         context.setVariable("endDate", dateFormat.format(endDate));
         context.setVariable("lessons", lessonDTOS);
+        context.setVariable("marksPieChartIsEmpty", markData.isEmpty());
+        context.setVariable("marksPieChart", marksPieChartString);
 
         return templateEngine.process("template" + File.separator + "thymeleaf_template", context);
     }
@@ -107,9 +129,38 @@ public class PDFServiceImpl implements PDFService {
     private void loadFonts(ITextRenderer renderer) throws DocumentException, IOException {
         Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(resourceLoader).getResources("classpath*:./fonts/*.ttf");
 
-        for (Resource res: resources) {
+        for (Resource res : resources) {
             renderer.getFontResolver().addFont("fonts" + File.separator + res.getFilename(), BaseFont.IDENTITY_H, BaseFont.NOT_EMBEDDED);
         }
+    }
+
+    private String createPieChartImageBase64(Map<String, Integer> data) throws IOException {
+
+        PieChart chart = new PieChartBuilder()
+                .width(1000)
+                .height(1000)
+                .build();
+
+        List<String> keys = data.keySet().stream().sorted().toList();
+
+        for (String key : keys) {
+            chart.addSeries(key, data.get(key));
+        }
+
+        chart.getStyler().setChartBackgroundColor(Color.WHITE);
+        chart.getStyler().setChartTitleVisible(false);
+        chart.getStyler().setPlotBorderVisible(false);
+
+        chart.getStyler().setLegendFont(chart.getStyler().getLegendFont().deriveFont(50f));
+        chart.getStyler().setLegendPadding(30);
+
+        chart.getStyler().setLabelType(PieStyler.LabelType.Value);
+        chart.getStyler().setLabelsDistance(.5);
+        chart.getStyler().setLabelsFont(chart.getStyler().getLabelsFont().deriveFont(35f));
+
+        byte[] marksPieChartByteArray = BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+        return Base64.encodeBase64String(marksPieChartByteArray);
+
     }
 
 }

--- a/src/main/resources/template/thymeleaf_template.html
+++ b/src/main/resources/template/thymeleaf_template.html
@@ -37,8 +37,28 @@
             text-transform: none;
         }
 
+        .subtitle2 {
+            font-size: 20px;
+            letter-spacing: 0;
+            word-spacing: 0;
+            color: #000000;
+            font-weight: 400;
+            text-decoration: none;
+            font-style: normal;
+            font-variant: normal;
+            text-transform: none;
+        }
+
+        .center {
+            text-align: center;
+        }
+
         .wrapper {
             margin: 20px 50px 20px 50px;
+
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
         }
 
         table.redTable {
@@ -89,6 +109,11 @@
             padding: 2px 8px;
             border-radius: 5px;
         }
+
+        .marks_pie_chart {
+            width: 300px;
+            height: 300px;
+        }
     </style>
 </head>
 <body>
@@ -117,6 +142,14 @@
             </tr>
             </tbody>
         </table>
+    </div>
+
+    <div>
+        <div class="subtitle">Успеваемость</div>
+        <div th:if="${marksPieChartIsEmpty}" class="subtitle2 center">Данные по успеваемости не найдены</div>
+        <div th:if="${!marksPieChartIsEmpty}">
+            <img class="marks_pie_chart" th:src="${'data:image/png;charset=utf-8;base64,' + marksPieChart}" alt=""/>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Задача оказалась не тривиальной, но я сделал это. 
Процесс добавления диаграммы:
- С помощью XChart создается сама диаграмма
- Диаграмма переводится в png изображение 1000x1000
- Изображение переводится в массив байтов
- Массив переводится в Base64 String
- Эта строка подставляется в тэг <img>
- По надобности изображение уменьшается до нужных размеров

Я пробовал использовать svg, но даже после 3 часов я не смог заставить диаграмму показываться(